### PR TITLE
Jdk8eclipse

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ with CommandPrompt (Windows)
      -DarchetypeGroupId=am.ik.archetype^
      -DarchetypeArtifactId=spring-boot-jersey-blank-archetype^
      -DarchetypeVersion=1.0.2
+	 
+If using Eclipse IDE (or other IDE), install Lombok:
+First, download dependencies into local Mavan repo to get Lombok jar:
+	
+	mvn dependency:resolve
+	
+Now run the Lombok installer from jar (one-off procedure):
+	
+    java -jar ~/.m2/repository/org/projectlombok/lombok/1.16.8/lombok-1.16.8.jar
 
 ### Example
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>am.ik.archetype</groupId>
     <artifactId>spring-boot-jersey-blank</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
 
     <name>Spring Boot Jersey Blank Project (from https://github.com/making/spring-boot-jersey-blank)</name>

--- a/src/main/java/xxxxxx/yyyyyy/zzzzzz/HelloEndpoint.java
+++ b/src/main/java/xxxxxx/yyyyyy/zzzzzz/HelloEndpoint.java
@@ -23,13 +23,6 @@ public class HelloEndpoint {
         return "Hello World!";
     }
 
-    @Data
-    static class Result {
-        private final int left;
-        private final int right;
-        private final long answer;
-    }
-
     // SQL sample
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/xxxxxx/yyyyyy/zzzzzz/Result.java
+++ b/src/main/java/xxxxxx/yyyyyy/zzzzzz/Result.java
@@ -1,0 +1,9 @@
+package xxxxxx.yyyyyy.zzzzzz;
+
+import lombok.Data;
+
+@Data class Result {
+    private final int left;
+    private final int right;
+    private final long answer;
+}


### PR DESCRIPTION
I made some minor changes to deal with later release of java8 as well as running the Lombok precompiler from an IDE build (Eclipse).  

Later releases of Java8 cause error `java.lang.VerifyError: Bad type on operand stack`
Solution is to change lombok version from 1.14.8 to 1.16.8.

Later releases of Java8 were getting the issue described here:
https://github.com/spring-projects/spring-loaded/issues/118
Solution is to change pom.xml parent "spring-boot-starter-parent" from 1.2.1 to 1.2.7

When building/running with Eclipse IDE (or other IDE) the Lombok precompiler cannot precompile the static inner class, `HelloEndpoint.Result` so a missing constructor error is raised. (no error in Maven command-line build/run).  Solution is to move `Result` into it's own compilation unit, `Result.java`.

I also updated `README.md` to explain how to install Lombok precompiler in IDE
